### PR TITLE
chore: updated version of node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ outputs:
   version:
     description: "Date version"
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Github actions are triggering the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: wendbv/calver-tag-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Also, `node16` is deprecated too:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: greatwizard/coverage-diff-action@v1. For more information see: [github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

This PR is updating the node version of the action from 12 to 20.